### PR TITLE
Support for GitHub Enterprise Server (GHES)

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -25,7 +25,10 @@ export default class GitHub {
   #octokit: ReturnType<typeof github.getOctokit>;
 
   constructor() {
-    this.#octokit = github.getOctokit(core.getInput('access-token'));
+    const baseUrl = process.env.GITHUB_API_URL || 'https://api.github.com';
+    this.#octokit = github.getOctokit(core.getInput('access-token'), {
+      baseUrl,
+    });
   }
 
   public async getTSFiles() {


### PR DESCRIPTION
Hello @ysk8hori 

Thank you for providing such an outstanding Workflow.

As a suggestion, I would like to propose adding support for GHES (GitHub Enterprise Server), as it would enable more users, including us, to benefit from these Actions in a broader range of environments.

To access GHES, the GITHUB_API_URL environment variable is required. Fortunately, thanks to GitHub Actions, this variable is automatically provided as a default environment variable, meaning no code changes are necessary to utilize it.
For more details, please refer to the official documentation:
[GitHub Actions - Default Environment Variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)

Please let us know if there are any changes or adjustments needed to align this contribution with your vision.