### PR TITLE
fix(metrics): メトリクス出力条件を改善し、変更対象ファイルがない場合は出力しないように修正  @ysk8hori

### DIFF
--- a/.github/workflows/test-dummy_project.yml
+++ b/.github/workflows/test-dummy_project.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Delta Typescript Graph
         id: tsg
-        uses: ysk8hori/delta-typescript-graph-action@fbec66d8e94e62c5f3a6921893b9e4c7d7abd4db
+        uses: ysk8hori/delta-typescript-graph-action@8ca233742696fdeadc7e057ff1772f8bd354d437
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
           tsconfig: './dummy_project/tsconfig-dummy.json'

--- a/.github/workflows/test-no-params.yml
+++ b/.github/workflows/test-no-params.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: ysk8hori/delta-typescript-graph-action@fbec66d8e94e62c5f3a6921893b9e4c7d7abd4db
+      - uses: ysk8hori/delta-typescript-graph-action@8ca233742696fdeadc7e057ff1772f8bd354d437
         with:
           max-size: 50

--- a/.github/workflows/test-with-params.yml
+++ b/.github/workflows/test-with-params.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Delta Typescript Graph
         id: tsg
-        uses: ysk8hori/delta-typescript-graph-action@fbec66d8e94e62c5f3a6921893b9e4c7d7abd4db
+        uses: ysk8hori/delta-typescript-graph-action@8ca233742696fdeadc7e057ff1772f8bd354d437
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
           tsconfig-root: './'

--- a/src/metrics/buildMetricsMessage.ts
+++ b/src/metrics/buildMetricsMessage.ts
@@ -47,11 +47,11 @@ export function buildMetricsMessage({
 }
 
 function generateScoreMetrics(
-  traverserForBase: ProjectTraverser,
+  traverser: ProjectTraverser,
   allModifiedFiles: PullRequestFileInfo[],
 ) {
   return pipe(
-    calculateCodeMetrics({ metrics: true }, traverserForBase, filePath =>
+    calculateCodeMetrics({ metrics: true }, traverser, filePath =>
       allModifiedFiles.map(v => v.filename).includes(filePath),
     ),
     unTree,

--- a/src/metrics/buildMetricsMessage.ts
+++ b/src/metrics/buildMetricsMessage.ts
@@ -34,13 +34,16 @@ export function buildMetricsMessage({
     return;
   }
 
-  write('## Metrics\n\n');
   const baseMetrics = generateScoreMetrics(traverserForBase, allModifiedFiles);
   const headMetrics = generateScoreMetrics(traverserForHead, allModifiedFiles);
 
   // メトリクスの差分を計算
   const { metricsMap, sortedKeys } = createScoreDiff(headMetrics, baseMetrics);
 
+  // 変更対象ファイルがトラバース対象に含まれない場合はメトリクスを出力しない
+  if (sortedKeys.length === 0) return;
+
+  write('## Metrics\n\n');
   // メトリクスの差分をファイルごとに書き込む
   formatAndOutputMetrics(sortedKeys, metricsMap, write);
   return;


### PR DESCRIPTION
トラバース対象に変更がない場合に Metrics のタイトルのみが出力されていたが、タイトルも出力しないよう改善。

▼ before
![image](https://github.com/user-attachments/assets/6905c50d-951c-4c6f-afc6-d24b02b96ff8)

▼ after
![image](https://github.com/user-attachments/assets/5fd86999-5dec-42de-a49b-d34d6bd24f53)
