### PR TITLE
fix: use relative path for includeList

### DIFF
--- a/.github/workflows/test-dummy_project.yml
+++ b/.github/workflows/test-dummy_project.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Delta Typescript Graph
         id: tsg
-        uses: ysk8hori/delta-typescript-graph-action@44b8652261a2d95e733bdc7068bde410ab7df09f
+        uses: ./
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
           tsconfig: './dummy_project/tsconfig-dummy.json'

--- a/.github/workflows/test-no-params.yml
+++ b/.github/workflows/test-no-params.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: ysk8hori/delta-typescript-graph-action@44b8652261a2d95e733bdc7068bde410ab7df09f
+      - uses: ./
         with:
           max-size: 50

--- a/.github/workflows/test-with-params.yml
+++ b/.github/workflows/test-with-params.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Delta Typescript Graph
         id: tsg
-        uses: ysk8hori/delta-typescript-graph-action@44b8652261a2d95e733bdc7068bde410ab7df09f
+        uses: ./
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
           tsconfig-root: './'

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -517,31 +517,6 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-is-plain-object
-MIT
-The MIT License (MIT)
-
-Copyright (c) 2014-2017, Jon Schlinkert.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-
 once
 ISC
 The ISC License
@@ -563,28 +538,6 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 remeda
 MIT
-MIT License
-
-Copyright (c) 2018 remeda
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 
 source-map
 BSD-3-Clause
@@ -786,7 +739,7 @@ zod
 MIT
 MIT License
 
-Copyright (c) 2020 Colin McDonnell
+Copyright (c) 2025 Colin McDonnell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/graph/createIncludeList.test.ts
+++ b/src/graph/createIncludeList.test.ts
@@ -1,11 +1,24 @@
 import type { Node, Relation } from '@ysk8hori/typescript-graph';
 import { isIncludeIndexFileDependencies } from '../utils/config';
+import type { Context } from '../utils/context';
 import { createIncludeList } from './createIncludeList';
 
 jest.mock('../utils/config', () => ({
   isIncludeIndexFileDependencies: jest.fn(),
 }));
 
+const baseConfig: Context["config"] = {
+  tsconfigRoot: './',
+  tsconfig: './tsconfig.json',
+  maxSize: 30,
+  orientation: { TB: true },
+  debugEnabled: false,
+  inDetails: false,
+  exclude: [],
+  includeIndexFileDependencies: false,
+  commentTitle: 'Delta TypeScript Graph Action',
+  showMetrics: false,
+};
 test('新規作成、更新、削除、リネーム前後のファイルが include 対象となる', () => {
   expect(
     createIncludeList({
@@ -40,6 +53,7 @@ test('新規作成、更新、削除、リネーム前後のファイルが incl
             },
           ],
         },
+        config: baseConfig,
       },
       // created: ['created.ts'],
       // deleted: ['deleted.ts'],
@@ -73,6 +87,7 @@ test('TSG_INCLUDE_INDEX_FILE_DEPENDENCIES が false の場合は include 対象�
           ],
           renamed: [],
         },
+        config: baseConfig,
       },
       // created: [],
       // deleted: [],
@@ -126,6 +141,7 @@ test('TSG_INCLUDE_INDEX_FILE_DEPENDENCIES が true の場合は include 対象�
           ],
           renamed: [],
         },
+        config: baseConfig,
       },
       graphs: [
         {
@@ -156,4 +172,56 @@ test('TSG_INCLUDE_INDEX_FILE_DEPENDENCIES が true の場合は include 対象�
       ],
     }),
   ).toEqual(['src/a.ts', 'src/index.ts']);
+});
+
+test('tsconfig が指定されている場合は相対パスで出力される', () => {
+  expect(
+    createIncludeList({
+      context: {
+        filesChanged: {
+          created: [],
+          deleted: [],
+          modified: [
+            {
+              filename: 'dummy_project/src/a.ts',
+              status: 'modified',
+              previous_filename: undefined,
+            },
+          ],
+          renamed: [],
+        },
+        config: {
+          ...baseConfig,
+          tsconfig: "./dummy_project/tsconfig-dummy.json",
+        },
+      },
+      graphs: [
+        {
+          nodes: [
+            {
+              changeStatus: 'not_modified',
+              name: 'a.ts',
+              path: 'dummy_project/src/a.ts',
+            } satisfies Node,
+          ],
+          relations: [
+            {
+              from: {
+                changeStatus: 'not_modified',
+                name: 'index.ts',
+                path: 'dummy_project/src/index.ts',
+              } satisfies Node,
+              to: {
+                changeStatus: 'not_modified',
+                name: 'a.ts',
+                path: 'dummy_project/src/a.ts',
+              } satisfies Node,
+              changeStatus: 'not_modified',
+              kind: 'depends_on',
+            } satisfies Relation,
+          ],
+        },
+      ],
+    }),
+  ).toEqual(['src/a.ts']);
 });


### PR DESCRIPTION
fix: #357

This pull request introduces updates to the workflows and enhances the `createIncludeList` functionality to support relative path outputs based on the specified `tsconfig`. Additionally, it includes new test cases to validate these changes.

### Workflow Updates:
* `.github/workflows/test-dummy_project.yml`, `.github/workflows/test-no-params.yml`, `.github/workflows/test-with-params.yml`: Updated the `uses` directive for the `delta-typescript-graph-action` to use the local repository (`./`) instead of a specific version. [[1]](diffhunk://#diff-5b715da57d1c834419d8e678af531cd948ddccfe447d2c9f7f96b647af9809b1L16-R16) [[2]](diffhunk://#diff-4a8c993a17bd97093984a83f35ecef46e547f9f32dd14af9a235f2406e2fea6dL14-R14) [[3]](diffhunk://#diff-2d95e3ad71be9df713651a3cee693bace319fb0f30f50762407a585934989e72L16-R16)

### Enhancements to `createIncludeList`:
* [`src/graph/createIncludeList.ts`](diffhunk://#diff-93a603be774cea08fbdd12befdaefc154ba4a6797c23a77cda047d160e7e7350R1): Modified `createIncludeList` to calculate relative paths for files based on the `tsconfig` or `tsconfigRoot` configuration. Introduced a new `baseDir` variable for this purpose. [[1]](diffhunk://#diff-93a603be774cea08fbdd12befdaefc154ba4a6797c23a77cda047d160e7e7350R1) [[2]](diffhunk://#diff-93a603be774cea08fbdd12befdaefc154ba4a6797c23a77cda047d160e7e7350R10-R27)

### Test Improvements:
* `src/graph/createIncludeList.test.ts`:
  - Added a `baseConfig` object to standardize configuration across tests.
  - Updated existing test cases to include the `config` property in the context. [[1]](diffhunk://#diff-3e61a2fe414612ffa1532f751cbf7140c5ca3622739df3075a68afee249302f2R56) [[2]](diffhunk://#diff-3e61a2fe414612ffa1532f751cbf7140c5ca3622739df3075a68afee249302f2R90) [[3]](diffhunk://#diff-3e61a2fe414612ffa1532f751cbf7140c5ca3622739df3075a68afee249302f2R144)
  - Added a new test case to verify that when a `tsconfig` is specified, file paths are output as relative paths.