### PR TITLE
fix: handle files outside tsconfig scope and fix highlighting with non-root tsconfig (#364, #365)

### DIFF
--- a/src/getFullGraph.ts
+++ b/src/getFullGraph.ts
@@ -9,7 +9,7 @@ import {
 import { anyPass, isNot, map, pipe } from 'remeda';
 import { getCreateGraphsArguments } from './tsg/getCreateGraphsArguments';
 import type { Context } from './utils/context';
-import { filterFilesInTsconfigScope } from './utils/tsconfigPath';
+import { isInTsconfigScope } from './utils/tsconfigPath';
 
 /** word に該当するか */
 const bindMatchFunc = (word: string) => (filePath: string) =>
@@ -83,9 +83,8 @@ function getGraph(
   const traverser = new ProjectTraverser(tsConfig);
 
   // Filter out files that are outside of the tsconfig scope
-  const filesInScope = filterFilesInTsconfigScope(
-    allChangedFiles,
-    context.config,
+  const filesInScope = allChangedFiles.filter(file =>
+    isInTsconfigScope(file, context.config),
   );
 
   // If no files are in scope, return an empty graph

--- a/src/graph/addStatus.ts
+++ b/src/graph/addStatus.ts
@@ -1,21 +1,35 @@
 import type { Graph, ChangeStatus } from '@ysk8hori/typescript-graph';
 import type { Context } from '../utils/context';
+import { convertToRelativePathsFromTsconfig } from '../utils/tsconfigPath';
 
 export default function addStatus(
   {
     filesChanged: { modified, created, deleted },
-  }: Pick<Context, 'filesChanged'>,
+    config,
+  }: Pick<Context, 'filesChanged' | 'config'>,
   graph: Graph,
 ): Graph {
   const { nodes, relations } = graph;
+
+  // Convert changed file paths to be relative to the tsconfig directory
+  const deletedPaths = convertToRelativePathsFromTsconfig(
+    deleted.map(({ filename }) => filename),
+    config,
+  );
+  const createdPaths = convertToRelativePathsFromTsconfig(
+    created.map(({ filename }) => filename),
+    config,
+  );
+  const modifiedPaths = convertToRelativePathsFromTsconfig(
+    modified.map(({ filename }) => filename),
+    config,
+  );
+
   const newNodes = nodes.map(node => {
     const changeStatus: ChangeStatus = (function () {
-      if (deleted.map(({ filename }) => filename).includes(node.path))
-        return 'deleted';
-      if (created.map(({ filename }) => filename).includes(node.path))
-        return 'created';
-      if (modified.map(({ filename }) => filename).includes(node.path))
-        return 'modified';
+      if (deletedPaths.includes(node.path)) return 'deleted';
+      if (createdPaths.includes(node.path)) return 'created';
+      if (modifiedPaths.includes(node.path)) return 'modified';
       return 'not_modified';
     })();
     return {

--- a/src/graph/addStatus.ts
+++ b/src/graph/addStatus.ts
@@ -1,6 +1,9 @@
 import type { Graph, ChangeStatus } from '@ysk8hori/typescript-graph';
 import type { Context } from '../utils/context';
-import { convertToRelativePathsFromTsconfig } from '../utils/tsconfigPath';
+import {
+  getRelativePathFromTsconfig,
+  isInTsconfigScope,
+} from '../utils/tsconfigPath';
 
 export default function addStatus(
   {
@@ -12,18 +15,18 @@ export default function addStatus(
   const { nodes, relations } = graph;
 
   // Convert changed file paths to be relative to the tsconfig directory
-  const deletedPaths = convertToRelativePathsFromTsconfig(
-    deleted.map(({ filename }) => filename),
-    config,
-  );
-  const createdPaths = convertToRelativePathsFromTsconfig(
-    created.map(({ filename }) => filename),
-    config,
-  );
-  const modifiedPaths = convertToRelativePathsFromTsconfig(
-    modified.map(({ filename }) => filename),
-    config,
-  );
+  const deletedPaths = deleted
+    .map(({ filename }) => filename)
+    .filter(filename => isInTsconfigScope(filename, config))
+    .map(filename => getRelativePathFromTsconfig(filename, config));
+  const createdPaths = created
+    .map(({ filename }) => filename)
+    .filter(filename => isInTsconfigScope(filename, config))
+    .map(filename => getRelativePathFromTsconfig(filename, config));
+  const modifiedPaths = modified
+    .map(({ filename }) => filename)
+    .filter(filename => isInTsconfigScope(filename, config))
+    .map(filename => getRelativePathFromTsconfig(filename, config));
 
   const newNodes = nodes.map(node => {
     const changeStatus: ChangeStatus = (function () {

--- a/src/graph/createIncludeList.test.ts
+++ b/src/graph/createIncludeList.test.ts
@@ -225,3 +225,34 @@ test('tsconfig が指定されている場合は相対パスで出力される',
     }),
   ).toEqual(['src/a.ts']);
 });
+
+test('tsconfig の範囲外のファイルは除外される', () => {
+  expect(
+    createIncludeList({
+      context: {
+        filesChanged: {
+          created: [],
+          deleted: [],
+          modified: [
+            {
+              filename: 'dummy_project/src/a.ts',
+              status: 'modified',
+              previous_filename: undefined,
+            },
+            {
+              filename: 'outside/file.ts',
+              status: 'modified',
+              previous_filename: undefined,
+            },
+          ],
+          renamed: [],
+        },
+        config: {
+          ...baseConfig,
+          tsconfig: "./dummy_project/tsconfig.json",
+        },
+      },
+      graphs: [],
+    }),
+  ).toEqual(['src/a.ts']);
+});

--- a/src/graph/createIncludeList.test.ts
+++ b/src/graph/createIncludeList.test.ts
@@ -7,7 +7,7 @@ jest.mock('../utils/config', () => ({
   isIncludeIndexFileDependencies: jest.fn(),
 }));
 
-const baseConfig: Context["config"] = {
+const baseConfig: Context['config'] = {
   tsconfigRoot: './',
   tsconfig: './tsconfig.json',
   maxSize: 30,
@@ -192,7 +192,7 @@ test('tsconfig が指定されている場合は相対パスで出力される',
         },
         config: {
           ...baseConfig,
-          tsconfig: "./dummy_project/tsconfig-dummy.json",
+          tsconfig: './dummy_project/tsconfig-dummy.json',
         },
       },
       graphs: [
@@ -249,7 +249,7 @@ test('tsconfig の範囲外のファイルは除外される', () => {
         },
         config: {
           ...baseConfig,
-          tsconfig: "./dummy_project/tsconfig.json",
+          tsconfig: './dummy_project/tsconfig.json',
         },
       },
       graphs: [],

--- a/src/graph/createIncludeList.ts
+++ b/src/graph/createIncludeList.ts
@@ -1,7 +1,10 @@
 import type { Graph } from '@ysk8hori/typescript-graph';
 import { isIncludeIndexFileDependencies } from '../utils/config';
 import type { Context } from '../utils/context';
-import { convertToRelativePathsFromTsconfig } from '../utils/tsconfigPath';
+import {
+  getRelativePathFromTsconfig,
+  isInTsconfigScope,
+} from '../utils/tsconfigPath';
 import { extractIndexFileDependencies } from './extractIndexFileDependencies';
 
 export function createIncludeList({
@@ -23,10 +26,9 @@ export function createIncludeList({
       .filter(Boolean) ?? []),
   ];
 
-  const relativePaths = convertToRelativePathsFromTsconfig(
-    allChangedFiles,
-    config,
-  );
+  const relativePaths = allChangedFiles
+    .filter(file => isInTsconfigScope(file, config))
+    .map(file => getRelativePathFromTsconfig(file, config));
 
   return isIncludeIndexFileDependencies()
     ? [

--- a/src/graph/createIncludeList.ts
+++ b/src/graph/createIncludeList.ts
@@ -1,34 +1,40 @@
-import path from 'node:path';
 import type { Graph } from '@ysk8hori/typescript-graph';
 import { isIncludeIndexFileDependencies } from '../utils/config';
 import type { Context } from '../utils/context';
+import { convertToRelativePathsFromTsconfig } from '../utils/tsconfigPath';
 import { extractIndexFileDependencies } from './extractIndexFileDependencies';
 
 export function createIncludeList({
   context: {
     filesChanged: { created, deleted, modified, renamed },
-    config: { tsconfigRoot, tsconfig },
+    config,
   },
   graphs,
 }: {
   context: Pick<Context, 'filesChanged' | 'config'>;
   graphs: Graph[];
 }) {
-  const baseDir = tsconfig ? path.dirname(tsconfig) : tsconfigRoot;
-  const tmp = [
+  const allChangedFiles = [
     ...created.map(({ filename }) => filename),
     ...deleted.map(({ filename }) => filename),
     ...modified.map(({ filename }) => filename),
     ...(renamed
       ?.flatMap(diff => [diff.previous_filename, diff.filename])
       .filter(Boolean) ?? []),
-  ]
-    .map(filename => path.relative(baseDir, filename))
-    .filter(filename => filename && !filename.startsWith('..'));
+  ];
+
+  const relativePaths = convertToRelativePathsFromTsconfig(
+    allChangedFiles,
+    config,
+  );
+
   return isIncludeIndexFileDependencies()
     ? [
-        ...tmp,
-        ...extractIndexFileDependencies({ graphs, includeFilePaths: tmp }),
+        ...relativePaths,
+        ...extractIndexFileDependencies({
+          graphs,
+          includeFilePaths: relativePaths,
+        }),
       ]
-    : tmp;
+    : relativePaths;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -95,6 +95,8 @@ export function getCommentTitle(): string {
   return core.getInput(COMMENT_TITLE) ?? 'Delta TypeScript Graph';
 }
 
+export type Config = ReturnType<typeof getConfig>;
+
 export function getConfig() {
   return {
     tsconfigRoot: getTsconfigRoot(),

--- a/src/utils/tsconfigPath.ts
+++ b/src/utils/tsconfigPath.ts
@@ -4,27 +4,21 @@ import type { Config } from './config';
 /**
  * Get the base directory for tsconfig
  */
-function getTsconfigBaseDir(config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>): string {
+function getTsconfigBaseDir(
+  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>,
+): string {
   return config.tsconfig ? path.dirname(config.tsconfig) : config.tsconfigRoot;
 }
 
 /**
  * Convert an absolute file path to a path relative to the tsconfig base directory
- * @returns null if the file is outside the tsconfig scope
  */
-function getRelativePathFromTsconfig(
+export function getRelativePathFromTsconfig(
   absolutePath: string,
-  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>
-): string | null {
+  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>,
+): string {
   const baseDir = getTsconfigBaseDir(config);
-  const relativePath = path.relative(baseDir, absolutePath);
-  
-  // Files outside tsconfig scope have relative paths starting with '..'
-  if (relativePath.startsWith('..')) {
-    return null;
-  }
-  
-  return relativePath;
+  return path.relative(baseDir, absolutePath);
 }
 
 /**
@@ -32,30 +26,8 @@ function getRelativePathFromTsconfig(
  */
 export function isInTsconfigScope(
   absolutePath: string,
-  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>
+  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>,
 ): boolean {
-  return getRelativePathFromTsconfig(absolutePath, config) !== null;
-}
-
-/**
- * Filter an array of file paths to only include those within the tsconfig scope
- */
-export function filterFilesInTsconfigScope(
-  filePaths: string[],
-  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>
-): string[] {
-  return filePaths.filter(filePath => isInTsconfigScope(filePath, config));
-}
-
-/**
- * Convert file paths to relative paths from tsconfig base directory
- * Only includes files within the tsconfig scope
- */
-export function convertToRelativePathsFromTsconfig(
-  filePaths: string[],
-  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>
-): string[] {
-  return filePaths
-    .map(filePath => getRelativePathFromTsconfig(filePath, config))
-    .filter((relativePath): relativePath is string => relativePath !== null);
+  const relativePath = getRelativePathFromTsconfig(absolutePath, config);
+  return !relativePath.startsWith('..');
 }

--- a/src/utils/tsconfigPath.ts
+++ b/src/utils/tsconfigPath.ts
@@ -1,0 +1,61 @@
+import path from 'node:path';
+import type { Config } from './config';
+
+/**
+ * Get the base directory for tsconfig
+ */
+export function getTsconfigBaseDir(config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>): string {
+  return config.tsconfig ? path.dirname(config.tsconfig) : config.tsconfigRoot;
+}
+
+/**
+ * Convert an absolute file path to a path relative to the tsconfig base directory
+ * @returns null if the file is outside the tsconfig scope
+ */
+export function getRelativePathFromTsconfig(
+  absolutePath: string,
+  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>
+): string | null {
+  const baseDir = getTsconfigBaseDir(config);
+  const relativePath = path.relative(baseDir, absolutePath);
+  
+  // Files outside tsconfig scope have relative paths starting with '..'
+  if (relativePath.startsWith('..')) {
+    return null;
+  }
+  
+  return relativePath;
+}
+
+/**
+ * Check if a file is within the tsconfig scope
+ */
+export function isInTsconfigScope(
+  absolutePath: string,
+  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>
+): boolean {
+  return getRelativePathFromTsconfig(absolutePath, config) !== null;
+}
+
+/**
+ * Filter an array of file paths to only include those within the tsconfig scope
+ */
+export function filterFilesInTsconfigScope(
+  filePaths: string[],
+  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>
+): string[] {
+  return filePaths.filter(filePath => isInTsconfigScope(filePath, config));
+}
+
+/**
+ * Convert file paths to relative paths from tsconfig base directory
+ * Only includes files within the tsconfig scope
+ */
+export function convertToRelativePathsFromTsconfig(
+  filePaths: string[],
+  config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>
+): string[] {
+  return filePaths
+    .map(filePath => getRelativePathFromTsconfig(filePath, config))
+    .filter((relativePath): relativePath is string => relativePath !== null);
+}

--- a/src/utils/tsconfigPath.ts
+++ b/src/utils/tsconfigPath.ts
@@ -4,7 +4,7 @@ import type { Config } from './config';
 /**
  * Get the base directory for tsconfig
  */
-export function getTsconfigBaseDir(config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>): string {
+function getTsconfigBaseDir(config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>): string {
   return config.tsconfig ? path.dirname(config.tsconfig) : config.tsconfigRoot;
 }
 

--- a/src/utils/tsconfigPath.ts
+++ b/src/utils/tsconfigPath.ts
@@ -12,7 +12,7 @@ function getTsconfigBaseDir(config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>): 
  * Convert an absolute file path to a path relative to the tsconfig base directory
  * @returns null if the file is outside the tsconfig scope
  */
-export function getRelativePathFromTsconfig(
+function getRelativePathFromTsconfig(
   absolutePath: string,
   config: Pick<Config, 'tsconfig' | 'tsconfigRoot'>
 ): string | null {


### PR DESCRIPTION
This pull request introduces several enhancements to improve TypeScript graph generation by ensuring file paths are properly scoped to the `tsconfig` configuration. The changes focus on filtering files outside the `tsconfig` scope, converting file paths to relative paths, and adding utility functions for handling `tsconfig`-related operations.

test run for this PR: https://github.com/toiroakr/delta-typescript-graph-action/pull/5

### Enhancements to TypeScript graph generation:

- **Filtering files outside `tsconfig` scope:**
  - Updated `getGraph` in `src/getFullGraph.ts` to filter files outside the `tsconfig` scope using the new `filterFilesInTsconfigScope` utility. If no files are in scope, an empty graph is returned.
  - Added a test case in `src/graph/createIncludeList.test.ts` to verify that files outside the `tsconfig` scope are excluded.

- **Converting file paths to relative paths:**
  - Modified `addStatus` in `src/graph/addStatus.ts` to convert file paths to relative paths from the `tsconfig` base directory using `convertToRelativePathsFromTsconfig`. This ensures consistency in file path handling.
  - Refactored `createIncludeList` in `src/graph/createIncludeList.ts` to use `convertToRelativePathsFromTsconfig` for generating relative paths and filtering files within the `tsconfig` scope.

### Utility functions for `tsconfig` operations:

- **New utilities in `src/utils/tsconfigPath.ts`:**
  - Introduced functions such as `getTsconfigBaseDir`, `getRelativePathFromTsconfig`, `isInTsconfigScope`, `filterFilesInTsconfigScope`, and `convertToRelativePathsFromTsconfig` to streamline `tsconfig`-related file path operations. These utilities centralize logic for determining file scope and converting paths.

### Minor changes:

- **Code cleanup and type addition:**
  - Added a `Config` type in `src/utils/config.ts` to improve type safety and readability.
  - Renamed variables in `src/getFullGraph.ts` for clarity (e.g., `includeFiles` → `allChangedFiles`).